### PR TITLE
Add Mateo Petel to the list of contributors

### DIFF
--- a/index.md
+++ b/index.md
@@ -190,6 +190,7 @@ Until I get FP Castle formally launched as a company I am accepting "members in 
 * Marty Stumpf
 * Mary Sheeran
 * Mariya I. Vasileva
+* Mateo Petel
 * Matt Noonan
 * Matthew Kolosick
 * Matthías Páll Gissurarson


### PR DESCRIPTION
## Summary

* Adds Mateo Petel to the FP Castle Members In Spirit list.
* Keeps the list ordered alphabetically by first name.

## Validation

* Confirmed `index.md` is the source file for the Members In Spirit list.
* Confirmed the correct alphabetical placement is after `Mariya I. Vasileva` and before `Matt Noonan`.